### PR TITLE
Add training script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,20 @@ Contributions are welcome! If you have suggestions or improvements, feel free to
 This project is open-source and available under the [MIT License](LICENSE).
 
 ---
+
+## Running the Training Script
+
+To train the model from the command line and save it to the `models` directory:
+
+```bash
+python train_model.py
+```
+
+## Running Tests
+
+Tests are written with `pytest`. After installing the dependencies listed in
+`requirements.txt`, run:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+scikit-learn
+joblib
+openpyxl

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -1,0 +1,11 @@
+import os
+import train_model
+
+
+def test_training(tmp_path):
+    df = train_model.load_data()
+    model, mse = train_model.train_model(df)
+    out_path = tmp_path / "model.joblib"
+    train_model.save_model(model, out_path)
+    assert out_path.exists()
+    assert mse >= 0

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import mean_squared_error
+import joblib
+import os
+
+
+def load_data(path: str = "Sleep_Data.xlsx"):
+    """Load dataset from Excel file."""
+    return pd.read_excel(path)
+
+
+def train_model(df: pd.DataFrame):
+    """Train a RandomForestRegressor using the dataset."""
+    if 'Sleep_Quality_Score' not in df.columns:
+        raise ValueError("Dataset must contain 'Sleep_Quality_Score' column")
+    X = df.drop(columns=['Sleep_Quality_Score'])
+    y = df['Sleep_Quality_Score']
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    model = RandomForestRegressor(random_state=42)
+    model.fit(X_train, y_train)
+    predictions = model.predict(X_test)
+    mse = mean_squared_error(y_test, predictions)
+    return model, mse
+
+
+def save_model(model, path: str = "models/model.joblib"):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    joblib.dump(model, path)
+
+
+def main():
+    df = load_data()
+    model, mse = train_model(df)
+    save_model(model)
+    print(f"Model trained. MSE: {mse:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scriptify model training into `train_model.py`
- add pytest-based tests for training
- document how to run training and testing in README
- list dependencies in `requirements.txt`

## Testing
- `python -m pytest -s tests/test_train_model.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684420f88fb88323b82848b61361de7e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a script to train a machine learning model for predicting sleep quality scores.
  - Added automated tests to verify the model training and saving process.
- **Documentation**
  - Expanded the README with instructions for running the training script and executing tests.
- **Chores**
  - Added a requirements file to simplify environment setup with necessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->